### PR TITLE
Fix error with Ruby 1.8.7 and Capybara

### DIFF
--- a/dreamhostrails.rb
+++ b/dreamhostrails.rb
@@ -78,6 +78,7 @@ gem "rake", "~>0.9.2"
 group :test do
   gem "cucumber-rails"
   gem "database_cleaner"
+  gem "capybara", "2.0.3"
 end
 
 gem 'rspec-rails', :group => [:development, :test]


### PR DESCRIPTION
Adds a version to the capybara gem in the Gemfile.  Since Capyara does not support Ruby 1.8.7 past Capybara 2.0.3.  And, currently, we are stuck using Ruby 1.8.7 on a Dreamhost shared server.
