### PR TITLE
Add `bundle exec` to rake commands

### DIFF
--- a/dreamhostrails.rb
+++ b/dreamhostrails.rb
@@ -186,8 +186,8 @@ append_file "app/views/layouts/application.html.haml", <<-CODE
 CODE
 end
 
-rake "db:create"
-rake "db:migrate"
+run "bundle exec rake db:create"
+run "bundle exec rake db:migrate"
 
 # Plugins
 run "rails g jquery:install --ui"


### PR DESCRIPTION
I added bundle exec in front of the rake create and migrate commands.  I needed this because I had another rake installed on my system and this is better to use in general.
