### PR TITLE
Added nokogiri version to gemfile

### DIFF
--- a/dreamhostrails.rb
+++ b/dreamhostrails.rb
@@ -61,6 +61,7 @@ group :development do
   gem 'susy'
 end
 
+gem "nokogiri", "< 1.6"
 gem "haml"
 gem "haml-rails"
 gem "paperclip", "~>2.0"


### PR DESCRIPTION
Nokogiri stopped supporting Ruby 1.8.7 with versions 1.6+ (https://www.ruby-forum.com/topic/4414615).  I added `gem "nokogiri", "< 1.6"` in the gemfile so that it would bundle when creating a project.
